### PR TITLE
Avoid timeout exception for reediting cases

### DIFF
--- a/auto_input.py
+++ b/auto_input.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 import settings
 
 def add_tax(x):
@@ -40,7 +41,12 @@ def assign_expenditure(row):
 
 
 def enter_forum(row):
-    wait.until(EC.presence_of_element_located((By.ID,'etr_group')))
+    try:
+        wait.until(EC.presence_of_element_located((By.ID,'etr_group')))
+    except TimeoutException:
+        wait.until(EC.presence_of_element_located((By.ID,'goto_F003_edit')))
+        driver.find_element(By.ID, "goto_F003_edit").click()
+        wait.until(EC.presence_of_element_located((By.ID,'etr_group')))
     dropdown_expense = driver.find_element(By.ID,'etr_group')
     select_expense = Select(dropdown_expense)
     select_expense.select_by_index(row.expenditure)


### PR DESCRIPTION
@yanami85  今年も利用させていただきます。更新ありがとうございます。

「研究遂行経費支出報告書」を既に編集したことがある場合に、「再度、編集する」というボタンを押さなければ編集画面に遷移せず、自動流し込みが失敗する場合を発見したため、対策しました。
再編集の場合には、編集画面にならないまま`TimeoutException`が発生するので、エラーをキャッチして編集ボタン（`#goto_F003_edit`）を押すようにしました。

`TimeoutException`が出ない（初回の）場合は、元のままの動作です。