### PR TITLE
Update for 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 1. [ChromeDriver](https://chromedriver.chromium.org/)をダウンロードして解凍
 2. 解凍した実行ファイルをこのレポジトリ直下に配置
 3. `cp settings_sample.py settings.py`
-4. コピーした `setting.py` にJシステムのログインIDとパスワードを記入
+4. コピーした `setting.py` にJシステムのログインIDとパスワードを記入（必要なら年度を変更）
 4. Mac/Linuxの場合は`DRIVER_PATH`から`.exe`を削除
 5. 必要なライブラリをインストール（pipやcondaなど）
 5. `python auto_input.py`

--- a/auto_input.py
+++ b/auto_input.py
@@ -14,7 +14,7 @@ def add_tax(x):
         return x.value
 
 def convert_date_to_flag(x):
-    this_year = 2022
+    this_year = settings.THIS_YEAR
     date_to_flag_map = {
         f"{this_year}-04": 1, f"{this_year}-05": 2, f"{this_year}-06": 3,
         f"{this_year}-07": 4, f"{this_year}-08": 5, f"{this_year}-09": 6,
@@ -87,7 +87,7 @@ if __name__ == '__main__':
 
     driver = webdriver.Chrome(executable_path=settings.DRIVER_PATH)
 
-    J_SYSTEM_URL = r"https://tyousa.jsps.go.jp/stu22/"
+    J_SYSTEM_URL = rf"https://tyousa.jsps.go.jp/stu{str(settings.THIS_YEAR)[-2:]}/"
     J_SYSTEM_ID = settings.J_SYSTEM_ID
     J_SYSTEM_PASS = settings.J_SYSTEM_PASS
 

--- a/auto_input.py
+++ b/auto_input.py
@@ -56,8 +56,8 @@ def enter_forum(row):
     select_date = Select(dropdown_date)
     select_date.select_by_index(row.date)
     
-    wait.until(EC.element_to_be_clickable((By.ID, str(row.determine_receipt))))
-    driver.find_element(By.ID,str(row.determine_receipt)).click()
+    # wait.until(EC.element_to_be_clickable((By.ID, str(row.determine_receipt))))
+    # driver.find_element(By.ID,str(row.determine_receipt)).click()
     
     wait.until(EC.presence_of_element_located((By.NAME,"etr_itemName")))
     driver.find_element(By.NAME,"etr_itemName").send_keys(row.item)

--- a/setting_sample.py
+++ b/setting_sample.py
@@ -2,6 +2,9 @@
 J_SYSTEM_ID = "xxxxxx" 
 J_SYSTEM_PASS = "xxxxxx"
 
+# 年度
+THIS_YEAR = 2023
+
 # Chromedriverのパス
 DRIVER_PATH = "chromedriver.exe"
 


### PR DESCRIPTION
- 領収書の有無の欄がなくなっているので、領収書の有無を入力するコードをコメントアウトしました（万一復活したときのために完全には消していません）
- 年度が変わるたびに年の判定やURL生成の部分がエラーを出すので、年をハードコードする代わりに`setting.py`において今年度を指定できるようにしました
![image](https://github.com/yanami85/JSPS_auto_input/assets/16277200/f8042d1e-6ca6-41af-93cc-b807e4f602dc)
